### PR TITLE
Add Codex config integration with TOML support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
-  "name": "mcp-installer",
+  "name": "@anaisbetts/mcp-installer",
   "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-installer",
+      "name": "@anaisbetts/mcp-installer",
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.0.1",
         "rimraf": "^6.0.1",
         "spawn-rx": "^4.0.0"
       },
       "bin": {
-        "mcp-youtube": "lib/index.mjs"
+        "mcp-installer": "lib/index.mjs"
       },
       "devDependencies": {
         "shx": "^0.3.4",
@@ -34,6 +35,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Ani Betts <anais@anaisbetts.org>",
   "license": "MIT",
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.0.1",
     "rimraf": "^6.0.1",
     "spawn-rx": "^4.0.0"


### PR DESCRIPTION
## Summary
- add the `@iarna/toml` dependency for reading and writing Codex configuration
- replace the Claude helpers with Codex-aware utilities that update `config.toml`
- ensure local installs also register MCP servers in Codex

## Testing
- npm run prepare

------
https://chatgpt.com/codex/tasks/task_e_68d056a95858832b8c42fe8a1d8958b8