### PR TITLE
Update README with Codex CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
 # mcp-installer - A MCP Server to install MCP Servers
 
-This server is a server that installs other MCP servers for you. Install it, and you can ask Claude to install MCP servers hosted in npm or PyPi for you. Requires `npx` and `uv` to be installed for node and Python servers respectively.
+This server is a server that installs other MCP servers for you. Install it, and you can ask the Codex CLI to install MCP servers hosted in npm or PyPi for you. Requires `npx` and `uv` to be installed for node and Python servers respectively.
 
 ![image](https://github.com/user-attachments/assets/d082e614-b4bc-485c-a7c5-f80680348793)
 
 ### How to install:
 
-Put this into your `claude_desktop_config.json` (either at `~/Library/Application Support/Claude` on macOS or `C:\Users\NAME\AppData\Roaming\Claude` on Windows):
+You can register the server with the Codex CLI by running:
 
-```json
-  "mcpServers": {
-    "mcp-installer": {
-      "command": "npx",
-      "args": [
-        "@anaisbetts/mcp-installer"
-      ]
-    }
-  }
+```bash
+codex mcp add mcp-installer --command npx --args @anaisbetts/mcp-installer
+```
+
+If you prefer to edit the configuration manually, add the following to your `~/.codex/config.toml` file:
+
+```toml
+[mcp_servers."mcp-installer"]
+command = "npx"
+args = ["@anaisbetts/mcp-installer"]
 ```
 
 ### Example prompts
 
-> Hey Claude, install the MCP server named mcp-server-fetch
+These are sample prompts you can issue through the Codex CLI:
 
-> Hey Claude, install the @modelcontextprotocol/server-filesystem package as an MCP server. Use ['/Users/anibetts/Desktop'] for the arguments
+> Codex, install the MCP server named mcp-server-fetch.
 
-> Hi Claude, please install the MCP server at /Users/anibetts/code/mcp-youtube, I'm too lazy to do it myself.
+> Codex, install the @modelcontextprotocol/server-filesystem package as an MCP server. Use ['/Users/anibetts/Desktop'] for the arguments.
 
-> Install the server @modelcontextprotocol/server-github. Set the environment variable GITHUB_PERSONAL_ACCESS_TOKEN to '1234567890'
+> Codex, please install the MCP server at /Users/anibetts/code/mcp-youtube; I'm too lazy to do it myself.
+
+> Codex, install the server @modelcontextprotocol/server-github and set the environment variable GITHUB_PERSONAL_ACCESS_TOKEN to '1234567890'.


### PR DESCRIPTION
## Summary
- replace the Claude desktop configuration instructions with Codex CLI guidance
- add a TOML configuration snippet for `~/.codex/config.toml`
- update the prompt examples to reference the Codex CLI

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68d0593d4038832b943740fdff2bb18b