### PR TITLE
Rename package for Codex branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mcp-installer - A MCP Server to install MCP Servers
+# mcp-installer-codex - A MCP Server to install MCP Servers
 
 This server is a server that installs other MCP servers for you. Install it, and you can ask Claude to install MCP servers hosted in npm or PyPi for you. Requires `npx` and `uv` to be installed for node and Python servers respectively.
 
@@ -10,10 +10,10 @@ Put this into your `claude_desktop_config.json` (either at `~/Library/Applicatio
 
 ```json
   "mcpServers": {
-    "mcp-installer": {
+    "mcp-installer-codex": {
       "command": "npx",
       "args": [
-        "@anaisbetts/mcp-installer"
+        "@anaisbetts/mcp-installer-codex"
       ]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@anaisbetts/mcp-installer",
+  "name": "@anaisbetts/mcp-installer-codex",
   "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@anaisbetts/mcp-installer",
+      "name": "@anaisbetts/mcp-installer-codex",
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
@@ -15,9 +15,10 @@
         "spawn-rx": "^4.0.0"
       },
       "bin": {
-        "mcp-installer": "lib/index.mjs"
+        "mcp-installer-codex": "lib/index.mjs"
       },
       "devDependencies": {
+        "@types/iarna__toml": "^2.0.5",
         "shx": "^0.3.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.3"
@@ -126,13 +127,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/iarna__toml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.5.tgz",
+      "integrity": "sha512-I55y+SxI0ayM4MBU6yfGJGmi4wRll6wtSeKiFYAZj+Z5Q1DVbMgBSVDYY+xQZbjIlLs/pN4fidnvR8faDrmxPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
       "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.8"
       }
@@ -1018,8 +1028,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@anaisbetts/mcp-installer",
+  "name": "@anaisbetts/mcp-installer-codex",
   "version": "0.5.0",
   "bin": {
-    "mcp-installer": "./lib/index.mjs"
+    "mcp-installer-codex": "./lib/index.mjs"
   },
   "description": "A MCP server to install other MCP servers",
   "main": "index.js",
@@ -18,6 +18,7 @@
     "spawn-rx": "^4.0.0"
   },
   "devDependencies": {
+    "@types/iarna__toml": "^2.0.5",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"

--- a/src/index.mts
+++ b/src/index.mts
@@ -14,7 +14,7 @@ import { parse as parseToml, stringify as stringifyToml } from "@iarna/toml";
 
 const server = new Server(
   {
-    name: "mcp-installer",
+    name: "mcp-installer-codex",
     version: "0.5.0",
   },
   {


### PR DESCRIPTION
## Summary
- rename the server registration to mcp-installer-codex
- update package metadata, README, and lockfile to use the Codex branding
- add TypeScript typings dependency so the prepare build succeeds under the new name

## Testing
- npm run prepare

------
https://chatgpt.com/codex/tasks/task_e_68d0593b8f20832ba48126632c4e11e6